### PR TITLE
updates to FunctionTask type hints, caching clarification

### DIFF
--- a/notebooks/2_intro_functiontask.ipynb
+++ b/notebooks/2_intro_functiontask.ipynb
@@ -191,7 +191,7 @@
     "import typing as ty\n",
     "\n",
     "@pydra.mark.task\n",
-    "def add_var_an(a, b) -> ty.NamedTuple(\"Output\", [(\"sum_a_b\", int)]):\n",
+    "def add_var_an(a, b) -> {\"sum_a_b\": int}:\n",
     "    return a + b\n",
     "\n",
     "\n",
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "@pydra.mark.task\n",
-    "def modf_an(a) -> ty.NamedTuple(\"Output\", [(\"fractional\", ty.Any), (\"integer\", ty.Any)]):\n",
+    "def modf_an(a) -> {\"fractional\": ty.Any, \"integer\": ty.Any}:\n",
     "    import math\n",
     "    return math.modf(a)\n",
     "\n",
@@ -352,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But we can also provide the  path where we want to store the results, let's create a temporary directory and a specific subdirectory \"task4\":"
+    "But we can also provide the path where we want to store the results. If a path is provided for the cache directory, then pydra will use the cached results of a node instead of recomputing the result. Let's create a temporary directory and a specific subdirectory \"task4\":"
    ]
   },
   {
@@ -644,7 +644,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.1"
   },
   "pycharm": {
    "stem_cell": {

--- a/notebooks/5_intro_shelltask.ipynb
+++ b/notebooks/5_intro_shelltask.ipynb
@@ -190,6 +190,7 @@
     "- `argstr`: a string, e.g. \"-o\", can be used to specify a flag if needed for the command argument; \n",
     "- `mandatory`: a bool, if True` pygra will raise an exception, if the argument is not provided;\n",
     "\n",
+    "The complete documentations for all suported keys is available [here](https://pydra.readthedocs.io/en/latest/input_spec.html).\n",
     " "
    ]
   },
@@ -509,7 +510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.1"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
- In FunctionTask output naming: Replacing named tuples with dictionaries. As the latter do not cause inconsistent hashes.
- Added a phrase explaining that caching only happens if a cache directory is provided.
- Provided a link to the input specification documentation.