### PR TITLE
change binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This tutorial will walk you through the main concepts of Pydra!
 
-You can run the notebooks locally or run using [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nipype/pydra-tutorial/master?filepath=notebooks)
+You can run the notebooks locally or run using [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nipype/pydra-tutorial/master)
 
 If you are running locally, be sure to install the necessary [requirements.](https://github.com/nipype/pydra-tutorial/blob/master/requirements.txt)
 


### PR DESCRIPTION
1. I changed the binder link, so it will load the whole repo in jupyter lab instead of only notebooks in jupyter notebook.
2. Regarding making cells hidden, I tried to add [cell tags](https://jupyterbook.org/en/stable/content/metadata.html#jupyter-cell-tags), but it didn't work.
A not-that-perfect solution would be using `<details></details>` in Markdown, such as:
<details>
<summary>Click to see answer</summary>
```
put python code here
```
</details>