### PR TITLE
Fix issue #40: Typo error in FunctionTask tutorial

### DIFF
--- a/notebooks/2_intro_functiontask.md
+++ b/notebooks/2_intro_functiontask.md
@@ -158,7 +158,7 @@ If we don't specify the input, `attr.NOTHING` will be used as the default value
 task3a = add_var()
 task3a.inputs.a = 4
 
-# importing attr library, and checking the type pf `b`
+# importing attr library, and checking the type of `b`
 import attr
 
 task3a.inputs.b == attr.NOTHING


### PR DESCRIPTION
Corrected the typo error in FunctionTask tutorial (from "pf" to "of") under section 2.2: setting the input.